### PR TITLE
Fix thread safety issues with IO messaging

### DIFF
--- a/Main.java
+++ b/Main.java
@@ -4,9 +4,7 @@ import de.re.eeip.cip.datatypes.Priority;
 import de.re.eeip.cip.datatypes.RealTimeFormat;
 import de.re.eeip.cip.exception.CIPException;
 
-import java.io.Console;
 import java.io.IOException;
-import java.util.List;
 
 /**
  * This example shows the Implicit Messaging of a Wago 750-352 in Java
@@ -46,18 +44,19 @@ public class Main
             eipClient.setT_O_priority(Priority.Urgent);
             eipClient.setT_O_variableLength(false);
             eipClient.setT_O_connectionType(ConnectionType.Multicast);
-            eipClient.O_T_IOData[0] = (byte)0xff;
+            eipClient.setO_T_IOData(new byte[] {(byte)0xff});
 
             System.out.println("Send Forward open to initiate IO Messaging");
             eipClient.ForwardOpen();
             for (int i = 0; i < 50; i++)
             {
-                System.out.println("Byte 0: "+eipClient.T_O_IOData[0]);
-                System.out.println("Byte 1: "+eipClient.T_O_IOData[1]);
-                System.out.println("Byte 2: "+eipClient.T_O_IOData[2]);
-                System.out.println("Byte 3: "+eipClient.T_O_IOData[3]);
-                System.out.println("Byte 4: "+eipClient.T_O_IOData[4]);
-                System.out.println("Byte 5: "+eipClient.T_O_IOData[5]);
+                byte[] T_O_IOData = eipClient.getT_O_IOData(6);
+                System.out.println("Byte 0: "+T_O_IOData[0]);
+                System.out.println("Byte 1: "+T_O_IOData[1]);
+                System.out.println("Byte 2: "+T_O_IOData[2]);
+                System.out.println("Byte 3: "+T_O_IOData[3]);
+                System.out.println("Byte 4: "+T_O_IOData[4]);
+                System.out.println("Byte 5: "+T_O_IOData[5]);
                 Thread.sleep(500);
             }
             System.out.println("Send Forward Close");

--- a/MainAllenBradley.java
+++ b/MainAllenBradley.java
@@ -53,15 +53,18 @@ public class MainAllenBradley
             eipClient.ForwardOpen();
             for (int i = 0; i < 50; i++)
             {
-                eipClient.O_T_IOData[0] = (byte)(eipClient.O_T_IOData[0]+1);
-                eipClient.O_T_IOData[1] = (byte)(eipClient.O_T_IOData[1]+1);
-                eipClient.O_T_IOData[2] = (byte)(eipClient.O_T_IOData[2]+1);
-                eipClient.O_T_IOData[3] = (byte)(eipClient.O_T_IOData[3]+1);
+                byte[] O_T_IOData = eipClient.getO_T_IOData(4);
+                O_T_IOData[0] = (byte)(O_T_IOData[0]+1);
+                O_T_IOData[1] = (byte)(O_T_IOData[1]+1);
+                O_T_IOData[2] = (byte)(O_T_IOData[2]+1);
+                O_T_IOData[3] = (byte)(O_T_IOData[3]+1);
+                eipClient.setO_T_IOData(O_T_IOData);
 
-                System.out.println("Input Module 1: "+eipClient.T_O_IOData[8]);
-                System.out.println("Input Module 2: "+eipClient.T_O_IOData[9]);
-                System.out.println("Input Module 3: "+eipClient.T_O_IOData[10]);
-                System.out.println("Input Module 4: "+eipClient.T_O_IOData[11]);
+                byte[] T_O_IOData = eipClient.getT_O_IOData(12);
+                System.out.println("Input Module 1: "+T_O_IOData[8]);
+                System.out.println("Input Module 2: "+T_O_IOData[9]);
+                System.out.println("Input Module 3: "+T_O_IOData[10]);
+                System.out.println("Input Module 4: "+T_O_IOData[11]);
                 Thread.sleep(500);
             }
             System.out.println("Send Forward Close");


### PR DESCRIPTION
I fixed some problems with IO messaging. O_T_IOData and T_O_IOData are accessed by two threads, so there is a need for locking to ensure correct visibility of the data. Also, it was possible to read/write these arrays while there were written/read by another thread. It may not be a problem when accessing single bytes, for example to read digital inputs, but there are some applications where you have to read the whole payload in a consistent way.
These changes require a small change of the API. I updated the 2 examples provided, but I was not able to test them because I do not have these devices.